### PR TITLE
chore(nodejs_CI.yml): migrate CI from travis to GitHub Actions

### DIFF
--- a/.github/workflows/nodejs_CI.yml
+++ b/.github/workflows/nodejs_CI.yml
@@ -1,7 +1,7 @@
 ---
 name: Node.js CI
 
-on:               
+on:
   pull_request:                    
     branches:
       - master                


### PR DESCRIPTION
affects: @evolsignal/learning-package-one, @evolsignal/learning-package-two